### PR TITLE
Replace h2 contents with bold contents header

### DIFF
--- a/docs/components/banners.md
+++ b/docs/components/banners.md
@@ -13,7 +13,7 @@ A [banner](https://material.io/components/banners) displays a prominent message 
 
 ![Hero image of a banner showing a transaction error message](assets/banners/banners_hero.png)
 
-## Contents
+**Contents**
 
 - [Using banners](#using-banners)
 - [Banners example](#banners-example)

--- a/docs/components/bottom_app_bars.md
+++ b/docs/components/bottom_app_bars.md
@@ -13,7 +13,7 @@ path: /catalog/material-bottom-app-bar/
 
 ![Example bottom app bar with inset floating action button](assets/bottom_app_bars/bottom-app-bar-hero.png)
 
-## Contents
+**Contents**
 
 - [Using the bottom app bar](#using-the-bottom-app-bar)
 - [Bottom app bar example](#bottom-app-bar-example)

--- a/docs/components/bottom_navigation.md
+++ b/docs/components/bottom_navigation.md
@@ -13,7 +13,7 @@ path: /components/bottom-navigation/
 
 ![Example bottom navigation bar with four icons along the bottom: favorites, music, places, and news. The music icon is selected](assets/bottom_navigation/Bottomnavigation_hero.png)
 
-## Contents
+**Contents**
 
 - [Using bottom navigation](#using-bottom-navigation)
 - [Bottom navigation example](#bottom-navigation-example)

--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -13,7 +13,7 @@ path: /catalog/material-button/
 
 ![Example Button with text learn more](assets/buttons/Buttons_hero.png)
 
-## Contents
+**Contents**
 
 - [Using buttons](#using-buttons)
 - [Text button](#text-button)

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -13,7 +13,7 @@ path: /catalog/material-card/
 
 ![Cards shaped in different ways](assets/cards/Cards_hero.png)
 
-## Contents
+**Contents**
 
 - [Using cards](#using-cards)
 - [Card](#card)

--- a/docs/components/checkboxes.md
+++ b/docs/components/checkboxes.md
@@ -19,7 +19,7 @@ Use checkboxes to:
 
 ![Checkbox hero example for menu options](assets/checkboxes/checkbox-hero.png)
 
-## Contents
+**Contents**
 
 - [Using checkboxes](#using-checkboxes)
 - [Checkboxes](#checkboxes)

--- a/docs/components/chips.md
+++ b/docs/components/chips.md
@@ -13,7 +13,7 @@ path: /catalog/material-chips/
 
 ![Hero image of an input chip](assets/chips/chips-hero.png)
 
-## Contents
+**Contents**
 
 - [Using chips](#using-chips)
 - [Anatomy and key properties](#anatomy-and-key-properties)

--- a/docs/components/data_tables.md
+++ b/docs/components/data_tables.md
@@ -14,7 +14,7 @@ api_doc_root: true
 
 ![Data table with 5 rows: 1 header row, 4 rows, one column of checkboxes](assets/data_tables/data-table-hero.png)
 
-## Contents
+**Contents**
 
 - [Using data tables](#using-data-tables)
 - [Theming data tables](#theming-data-tables)

--- a/docs/components/date_pickers.md
+++ b/docs/components/date_pickers.md
@@ -13,7 +13,7 @@ path: /catalog/date-pickers/
 
 ![Mobile date picker for November 2018 with "17" selected.](assets/date_pickers/pickers_hero.png)
 
-## Contents
+**Contents**
 
 - [Using date pickers](#using-pickers)
 - [Making date pickers accessible](#making-pickers-accessible)

--- a/docs/components/dialogs.md
+++ b/docs/components/dialogs.md
@@ -13,7 +13,7 @@ path: /catalog/dialog/
 
 ![Dialogs Hero](assets/dialogs/dialogs_hero.png)
 
-## Contents
+**Contents**
 
 - [Types](#types)
 - [Using banners](#using-dialogs)

--- a/docs/components/dividers.md
+++ b/docs/components/dividers.md
@@ -13,7 +13,7 @@ A [divider](https://material.io/components/dividers) is a thin line that groups 
 
 ![Example divider: full-bleed dividers](assets/dividers/Dividers_hero.png)
 
-## Contents
+**Contents**
 
 - [Making dividers accessible](#making-dividers-accessible)
 - [Anatomy and key properties](#anatomy-and-key-properties)

--- a/docs/components/fab.md
+++ b/docs/components/fab.md
@@ -12,7 +12,7 @@ path: /catalog/floating-action-button/
 A floating action button (FAB) represents the primary action of a screen.
 ![List with Regular FAB application](assets/fabs/FABs_hero.png)
 
-## Contents
+**Contents**
 
 - [Using FABs](#using-fabs)
 - [Regular FABs](#regular-fabs)

--- a/docs/components/lists.md
+++ b/docs/components/lists.md
@@ -11,7 +11,7 @@ path: /catalog/lists/
 
 [Lists](https://material.io/components/lists/) are continuous, vertical indexes of text or images.
 
-## Contents
+**Contents**
 
 - [Using lists](#using-lists)
 - [Single-line list](#single-line-list)

--- a/docs/components/menus.md
+++ b/docs/components/menus.md
@@ -14,7 +14,7 @@ api_doc_root: true
 
 ![Menu hero example showing two cascading menus](assets/menus/menus-hero.png)
 
-# Contents
+**Contents**
 
 - [Using menus](#using-menus)
 - [Anatomy](#anatomy)

--- a/docs/components/nav_drawer.md
+++ b/docs/components/nav_drawer.md
@@ -13,7 +13,7 @@ A [navigation drawer](https://material.io/components/navigation-drawer) provides
 
 ![Hero navigation drawer image](assets/nav_drawer/NavDrawer-hero.png)
 
-## Contents
+**Contents**
 
 - [Using a navigation drawer](#using-a-navigation-drawer)
 - [Anatomy](#anatomy)

--- a/docs/components/progress_indicators.md
+++ b/docs/components/progress_indicators.md
@@ -13,7 +13,7 @@ path: /catalog/material-progress-indicators/
 
 ![Progress indicator hero](assets/progress_indicators/hero-1.gif)
 
-## Contents
+**Contents**
 
 - [Using progress indicators](#using-progress-indicators)
 - [Types](#types)

--- a/docs/components/radio_buttons.md
+++ b/docs/components/radio_buttons.md
@@ -19,7 +19,7 @@ Use radio buttons to:
 
 ![Radio button hero example for menu options](assets/radio_buttons/RadioButton-hero.png)
 
-## Contents
+**Contents**
 
 - [Selection controls: radio buttons](#selection-controls-radio-buttons)
   - [Contents](#contents)

--- a/docs/components/sliders.md
+++ b/docs/components/sliders.md
@@ -14,7 +14,7 @@ selections from a range of values.
 
 !["Slider with sound icon buttons on each end."](assets/sliders/sliders_hero.png)
 
-## Contents
+**Contents**
 
 - [Using sliders](#using-sliders)
 - [Continuous slider](#continuous-slider)

--- a/docs/components/snackbars.md
+++ b/docs/components/snackbars.md
@@ -13,7 +13,7 @@ path: /catalog/Snackbars/
 
 ![Snackbars hero image](assets/snackbars/snackbars-hero.png)
 
-## Contents
+**Contents**
 
 - [Using snackbars](#using-snackbars)
 - [Snackbars example](#snackbar-example)

--- a/docs/components/switches.md
+++ b/docs/components/switches.md
@@ -15,7 +15,7 @@ Switches toggle the state of a single setting on or off. They are the preferred 
 
 ![Switch hero example for menu options](assets/switches/switch-hero.png)
 
-## Contents
+**Contents**
 
 - [Using switches](#using-switches)
 - [Switch anatomy](#switch-anatomy)

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -13,7 +13,7 @@ path: /catalog/tabs
 
 ![fixed tab example](assets/tabs/tabs_hero.png)
 
-## Contents
+**Contents**
 
 - [Using tabs](#using-tabs)
 - [Fixed tabs](#fixed-tabs)

--- a/docs/components/text_fields.md
+++ b/docs/components/text_fields.md
@@ -13,7 +13,7 @@ path: /catalog/material-text-field/
 
 ![Three text fiels: title, price, location](assets/text_fields/Textfields_hero.png)
 
-## Contents
+**Contents**
 
 - [Using text fields](#using-text-fields)
 - [Filled text](#filled-text)

--- a/docs/components/time_pickers.md
+++ b/docs/components/time_pickers.md
@@ -13,8 +13,7 @@ path: /catalog/time-pickers/
 
 ![Time picker with input and dial set to 7PM](assets/time_pickers/TimePicker_hero.png)
 
-
-## Contents
+**Contents**
 
 - [Using time pickers](#using-time-pickers)
 - [Making time pickers accessible](#making-time-pickers-accessible)

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -13,7 +13,7 @@ path: /catalog/Tooltips/
 
 ![Tooltip for "Bold" in a text editor menu](assets/tooltips/Tooltips_hero.png)
 
-## Contents
+**Contents**
 
 - [Using tooltips](#using-tooltips)
 - [Tooltips example](#tooltips-example)

--- a/docs/components/top_app_bars.md
+++ b/docs/components/top_app_bars.md
@@ -13,7 +13,7 @@ The [top app bar](https://material.io/components/app-bars-top/#) displays inform
 
 ![Top App Bar with Page Title](assets/top_app_Bars/../top_app_bars/Topappbars_hero.png)
 
-## Contents
+**Contents**
 
 - [Using the top app bar](#using-the-top-app-bar)
 - [Regular top app bar](#regular-top-app-bar)


### PR DESCRIPTION
The first "h2" or "##" header should no longer be "Contents." This replaces all "## Contents" with "**Contents**" So the first "h2" is "## Using foo..."
