### PR TITLE
update to image alt-texts

### DIFF
--- a/docs/components/banners.md
+++ b/docs/components/banners.md
@@ -11,7 +11,7 @@ path: /catalog/material-banners/
 
 A [banner](https://material.io/components/banners) displays a prominent message and related optional actions.
 
-![Hero image of a banner showing a transaction error message](assets/banners/banners_hero.png)
+![White banner showing a transaction error message in black and purple "Learn more" and "Fix it" text buttons](assets/banners/banners_hero.png)
 
 **Contents**
 
@@ -90,7 +90,7 @@ Banners consist of the following:
 
 The following example shows a banner being used with an icon and two actions.
 
-!["Regular banner example for Flutter."](assets/banners/banners-regular.png)
+![White banner w/ white trash icon in purple circle and black error message above two purple action text buttons](assets/banners/banners-regular.png)
 
 ```dart
 MaterialBanner(
@@ -122,7 +122,7 @@ customized in terms of color and typography.
 
 The following example shows a banner with the [Material Shrine Theme](https://material.io/design/material-studies/shrine.html).
 
-!["Banner with Shrine theming."](assets/banners/banners-theming.png)
+![Light pink banner w/ brown trash icon in pink circle and brown error message above two pink action text buttons](assets/banners/banners-theming.png)
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/components/chips.md
+++ b/docs/components/chips.md
@@ -11,7 +11,7 @@ path: /catalog/material-chips/
 
 [Chips](https://material.io/components/chips) are compact elements that represent an input, attribute, or action.
 
-![Hero image of an input chip](assets/chips/chips-hero.png)
+![Chip in email application in the "To" field: profile thumbnail and name in a rounded grey container](assets/chips/chips-hero.png)
 
 **Contents**
 
@@ -87,7 +87,7 @@ Input chips represent a complex piece of information in compact form, such as an
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/chip.dart)
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/chips/input&gh_ref=develop)
 
-![Input Chips](assets/chips/input_chips.png)
+![List of 3 input chips with "-" icons and text in black, and grey containers.](assets/chips/input_chips.png)
 
 ```dart
 @override
@@ -139,7 +139,7 @@ Choice chips clearly delineate and display options in a compact area. They are a
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/chip.dart)
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/chips/choice&gh_ref=develop)
 
-![Choice Chips](assets/chips/choice_chips.png)
+![List of 4 choice chips: choice 1 selected w/ blue container and text, choices 2-4 w/ grey container and black text](assets/chips/choice_chips.png)
 
 ```dart
 @override
@@ -192,7 +192,7 @@ Filter chips clearly delineate and display options in a compact area. They are a
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/chip.dart)
 - [Demo site](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/chips/filter)
 
-![Filter Chips](assets/chips/filter_chips.png)
+![Filter chips: 4 unselected w/ grey containers and black text, 2 selected w/ dark grey containers and black text & checkmarks](assets/chips/filter_chips.png)
 
 ```dart
 @override
@@ -255,7 +255,7 @@ An alternative to action chips are buttons, which should appear persistently and
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/chip.dart)
 - [Demo site](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/chips/action)
 
-![Action Chips](assets/chips/action_chips.png)
+![4 action chips w/ grey containers, black text and icons: favorite, trash, alarm, location](assets/chips/action_chips.png)
 
 ```dart
 @override
@@ -310,7 +310,7 @@ Chips support [Material Theming](https://material.io/components/chips/#theming) 
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/chip.dart)
 - [Demo site](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/chips/theme)
 
-![Theme Chips](assets/chips/theme_chips.png)
+![3 input chips w/ black text, grey containers, and brown icons: cart, redeem, and payment](assets/chips/theme_chips.png)
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/components/dividers.md
+++ b/docs/components/dividers.md
@@ -11,7 +11,7 @@ path: /catalog/material-dividers/
 
 A [divider](https://material.io/components/dividers) is a thin line that groups content in lists and layouts.
 
-![Example divider: full-bleed dividers](assets/dividers/Dividers_hero.png)
+![Grey inset dividers separating emails](assets/dividers/Dividers_hero.png)
 
 **Contents**
 
@@ -64,7 +64,7 @@ Full-bleed dividers separate content into sections and span the entire length of
 
 The following example shows a list with full-bleed dividers:
 
-![Full bleed divider](assets/dividers/full_bleed_divider.png)
+![2 grey dividers span the screen width, divided by text "Item 4"](assets/dividers/full_bleed_divider.png)
 
 ```dart
 Divider(),
@@ -82,7 +82,7 @@ Inset dividers separate related content, anchored by elements that align with th
 
 The following example shows two lists separated by an inset divider and a subheader
 
-![Inset divider](assets/dividers/inset_divider.png)
+![Grey line spanning screen with margin between left-hand screen and divider edge. "Subheader" in grey beneath divider](assets/dividers/inset_divider.png)
 
 ```dart
 Divider(indent: 16),
@@ -113,7 +113,7 @@ Middle dividers space related content and are centered in a layout or list.
 
 The following example shows a middle divider separating a list of items and their prices and the total cost:
 
-![Middle divider](assets/dividers/middle_divider.png)
+![Grey line spanning screen with margins on either side of line](assets/dividers/middle_divider.png)
 
 ```dart
 Divider(
@@ -132,7 +132,7 @@ Vertical divider offers the same parameters as the regular divider but instead t
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/divider.dart)
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/dividers/vertical_divider&gh_ref=develop)
 
-![Vertical divider](assets/dividers/vertical_divider.png)
+![Grey line spanning screen height](assets/dividers/vertical_divider.png)
 
 ```dart
 VerticalDivider()

--- a/docs/components/progress_indicators.md
+++ b/docs/components/progress_indicators.md
@@ -11,7 +11,7 @@ path: /catalog/material-progress-indicators/
 
 [Progress indicators](https://material.io/components/progress-indicators) express an unspecified wait time or display the length of a process.
 
-![Progress indicator hero](assets/progress_indicators/hero-1.gif)
+![Progress indicator animation: Purple bar travelling along a light purple line](assets/progress_indicators/hero-1.gif)
 
 **Contents**
 
@@ -83,7 +83,7 @@ Linear progress indicators display progress by animating an indicator along the 
 
 The following example shows an indeterminate linear progress indicator:
 
-![Linear Progress Indicator](assets/progress_indicators/linear_progress_indicator.png)
+![Blue linear progress indicator bar on a light blue linear track](assets/progress_indicators/linear_progress_indicator.png)
 
 ```dart
 body: Center(
@@ -99,7 +99,7 @@ Circular progress indicators display progress by animating an indicator along an
 - Determinate circular indicators fill the invisible, circular track with color, as the indicator moves from 0 to 360 degrees.
 - Indeterminate circular indicators grow and shrink in size while moving along the invisible track.
 
-![Circular Progress Indicator](assets/progress_indicators/circular_progress_indicator.png)
+![Circular progress indicator: a blue semi-circle](assets/progress_indicators/circular_progress_indicator.png)
 
 ### Circular progress indicator example
 
@@ -134,7 +134,7 @@ body: Center(
 
 The following shows an indeterminate linear progress indicator and a determinate circular progress indicator with [Shrine theming](https://material.io/design/material-studies/shrine.html):
 
-![Circular Progress Indicator](assets/progress_indicators/theme_progress_indicator.png)
+![Top: Pink linear track with brown indicator. Bottom: invisible circular track with brown indicator](assets/progress_indicators/theme_progress_indicator.png)
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/components/radio_buttons.md
+++ b/docs/components/radio_buttons.md
@@ -17,7 +17,7 @@ Use radio buttons to:
 - Expose all available options
 - If available options can be collapsed, consider using a dropdown menu instead, as it uses less space.
 
-![Radio button hero example for menu options](assets/radio_buttons/RadioButton-hero.png)
+!["Settings" radio buttons: 4 radio buttons, one selected with purple outline and purple circle.](assets/radio_buttons/RadioButton-hero.png)
 
 **Contents**
 
@@ -63,9 +63,9 @@ For more guidance on writing labels, go to [our page on how to write a good acce
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/radio.dart)
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/radio_buttons/regular&gh_ref=develop)
 
-The following example shows radio buttons being used in a list with the last row disabled.
+The following example shows radio buttons in a list, with the first row selected and the last row disabled.
 
-!["Regular radio button example for Flutter."](assets/radio_buttons/radio-button-regular.png)
+![Radio buttons: 1 w/ black text and purple outline/fill, 3 w/ black text and grey outline, 1 w/ light-grey text and outline](assets/radio_buttons/radio-button-regular.png)
 
 ```dart
 Column(
@@ -106,9 +106,9 @@ Radio buttons can be selected or unselected. Radio buttons have enabled, disable
 Radio buttons support [Material Theming](https://material.io/components/buttons/#theming) and can be
 customized in terms of color.
 
-The following example shows radio buttons with the [Material Shrine Theme](https://material.io/design/material-studies/shrine.html).
+The following example shows radio buttons with the [Material Shrine Theme](https://material.io/design/material-studies/shrine.html). The first row is selected, the last row is disabled.
 
-!["Radio buttons with Shrine theming."](assets/radio_buttons/radio-button-theming.png)
+![Radio buttons: 1 w/ brown text and  pink outline/fill, 3 w/ brown text and grey outline, 1 w/ light-grey text and outline](assets/radio_buttons/radio-button-theming.png)
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/components/sliders.md
+++ b/docs/components/sliders.md
@@ -12,7 +12,7 @@ path: /catalog/sliders/
 [Sliders](https://material.io/components/sliders/) allow users to make
 selections from a range of values.
 
-!["Slider with sound icon buttons on each end."](assets/sliders/sliders_hero.png)
+![Purple slider with mute icon on one end and volume up icon on the other end.](assets/sliders/sliders_hero.png)
 
 **Contents**
 
@@ -37,7 +37,7 @@ For more guidance on writing labels, go to [our page on how to write a good acce
 
 There are two types of sliders: 1\. [Continuous](#continuous-sliders) 2\. [Discrete](#discrete-sliders)
 
-!["Slider examples of both continuous and discrete sliders."](assets/sliders/sliders_types.png)
+![Slider examples of both continuous and discrete sliders.](assets/sliders/sliders_types.png)
 
 A slider with one thumb is called a single point slider, and a slider with two thumbs is called a range slider.
 
@@ -110,7 +110,7 @@ API and source code:
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/sliders/continous_slider&gh_ref=develop)
 - [YouTube video](https://www.youtube.com/watch?v=ufb4gIPDmEs&list=PLjxrf2q8roU23XGwz3Km7sQZFTdB996iG&index=58&ab_channel=Flutter)
 
-!["Continous Slider"](assets/sliders/continous_slider.png)
+![Blue slider with blue thumb and light blue track](assets/sliders/continous_slider.png)
 
 ```dart
 double _sliderValue = 20;
@@ -139,7 +139,7 @@ API and source code:
 
 API and source code:
 
-!["Range Sliders continuous example"](assets/sliders/continous_range_slider.png)
+![Blue slider with two blue thumbs and light blue track](assets/sliders/continous_range_slider.png)
 
 ```dart
   RangeValues _rangeSliderDiscreteValues = const RangeValues(40, 80);
@@ -172,7 +172,7 @@ API and source code:
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/slider.dart)
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/sliders/discrete_slider&gh_ref=develop)
 
-!["Discrete Sliders example"](assets/sliders/discrete_slider.png)
+![Blue slider with blue thumb on light blue track. A dark grey popup and white "40" points to the thumb](assets/sliders/discrete_slider.png)
 
 ```dart
 double _sliderDiscreteValue = 20;
@@ -198,7 +198,7 @@ API and source code:
 - [GitHub source](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/range_slider.dart)
 - [Dartpad demo](https://dartpad.dev/embed-flutter.html?gh_owner=material-components&gh_repo=material-components-flutter&gh_path=docs/components/dartpad/sliders/discrete_range_slider&gh_ref=develop)
 
-!["Discrete Range Sliders example"](assets/sliders/discrete_range_slider.png)
+![2 blue thumbs on light blue slider track. 2 dark grey popups w/ white text point to the thumbs; "20" and "80", respectively](assets/sliders/discrete_range_slider.png)
 
 ```dart
 RangeValues _rangeSliderDiscreteValues = const RangeValues(40, 80);
@@ -235,8 +235,8 @@ API and source code:
 
 The following example shows a discrete range slider with Material's [Shrine](https://material.io/design/material-studies/shrine.html) theme.
 
-!["Shrine theme example for Slider"](assets/sliders/theme_slider.png)
-!["Shrine theme example for Range Slider"](assets/sliders/theme_range_sliders.png)
+![Pink thumb on a light pink slider track](assets/sliders/theme_slider.png)
+![2 pink thumbs on a light pink slider track](assets/sliders/theme_range_sliders.png)
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/components/snackbars.md
+++ b/docs/components/snackbars.md
@@ -11,7 +11,7 @@ path: /catalog/Snackbars/
 
 [Snackbars](https://material.io/components/snackbars) provide brief messages about app processes at the bottom of the screen.
 
-![Snackbars hero image](assets/snackbars/snackbars-hero.png)
+![Black snack bar w/ purple "RETRY" text button over image list](assets/snackbars/snackbars-hero.png)
 
 **Contents**
 
@@ -72,7 +72,7 @@ The following is an anatomy diagram of a snackbar:
 
 The following is an example of a snackbar with an action button:
 
-![Snackbar example](assets/snackbars/snackbars-regular.png)
+![Black snackbar w/ white "Text label" and purple "Action" text button over image of coconuts](assets/snackbars/snackbars-regular.png)
 
 ```dart
 SnackBar(
@@ -95,7 +95,7 @@ SnackBar(
 
 The following is an example of a snackbar with an action button that uses the Material.io [Shrine](https://material.io/design/material-studies/shrine.html) color theming::
 
-![Snackbar with Shrine theme example](assets/snackbars/snackbars-themed.png)
+![Brown snackbar w/ pink "Text label" and white "Action" text button over image of coconuts](assets/snackbars/snackbars-themed.png)
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/components/switches.md
+++ b/docs/components/switches.md
@@ -68,7 +68,7 @@ The following is an anatomy diagram that shows a switch thumb and a switch track
 
 The following example shows switches being used in a list with the last row disabled.
 
-!["Regular switches example for Flutter."](assets/switches/switch-regular.png)
+!["Setting" switches with 4 options: 2 selected w/ purple thumbs and tracks, 2 unselected w/ grey thumbs track](assets/switches/switch-regular.png)
 
 ```dart
 Column(
@@ -120,7 +120,7 @@ customized in terms of color.
 
 The following example shows switches with the [Material Shrine Theme](https://material.io/design/material-studies/shrine.html).
 
-!["Switches with Shrine theming."](assets/switches/switch-theming.png)
+![5 switches: 2 active w/ pink thumbs and tracks, 2 inactive w/ white thumb and grey track, 1 inactive w/ grey thumb and track](assets/switches/switch-theming.png)
 
 ```dart
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Image alt-text updates to the following documents:

- Selection Controls: Radio Buttoms
- Selection Controls: Switches
- Chips
- Snackbars
- Banners
- Progress Indicators
- Sliders
- Dividers

