### PR TITLE
Update exposed dropdown menu example

### DIFF
--- a/docs/components/dartpad/menus/exposed_dropdown/main.dart
+++ b/docs/components/dartpad/menus/exposed_dropdown/main.dart
@@ -20,18 +20,18 @@ class ExposedDropdownMenuDemo extends StatefulWidget {
 }
 
 class _ExposedDropdownMenuDemoState extends State<ExposedDropdownMenuDemo> {
-  String dropdownValue = 'Option 1';
+  String dropdownValue = 'Option 2';
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Exposed Menu Demo'),
+        title: const Text('Exposed Menu Demo'),
       ),
       body: Center(
-        child: DropdownButton(
+        child: DropdownButton<String>(
           value: dropdownValue,
-          items: <DropdownMenuItem>[
+          items: const <DropdownMenuItem<String>>[
             DropdownMenuItem(
               value: 'Option 1',
               child: Text('Option 1'),
@@ -59,7 +59,7 @@ class _ExposedDropdownMenuDemoState extends State<ExposedDropdownMenuDemo> {
           ],
           onChanged: (value) {
             setState(() {
-              dropdownValue = value;
+              dropdownValue = value as String;
             });
           },
         ),
@@ -67,3 +67,5 @@ class _ExposedDropdownMenuDemoState extends State<ExposedDropdownMenuDemo> {
     );
   }
 }
+
+


### PR DESCRIPTION
The current version of Dart in Dartpad gets an error on the existing example.  This fix updates the example to specify the type for the dropdown value which resolves the error.

## Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Are you sure you mean this repo? This repository is a reference to the [main Flutter repository](https://github.com/flutter/flutter). Code-level issues should be created there.
I don't see a copy of this "docs" directory in the regular flutter repository, so I think this is where it belongs.
- [ ] Link to GitHub issues it solves. ```closes #1234```
I didn't make an issue first as it's clearly not good to get an error in the current Dartpad
- [ ] Sign the CLA bot. You can do this once the pull request is opened.
-OK

Be sure to read the [Flutter guide on contributing](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md).

### Related issues
 - Type `#` and the issue number or `#` and select the from the inline drop down.
